### PR TITLE
Bumped js-yaml from 3.12.0 to 3.13.1

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,7 +6,10 @@ Salesforce Marketing Cloud Fuel SDK for Node
 ## Overview ##
 The Fuel SDK for Node provides easy access to Salesforce Marketing Cloud's Fuel API Family services, including a collection of REST APIs and a SOAP API. These APIs provide access to Salesforce Marketing Cloud functionality via common collection types. 
 
-## Latest Version 2.3.0 ##
+## Latest Version 2.3.1 ##
+Bumped [js-yaml](https://github.com/nodeca/js-yaml) from 3.12.0 to 3.13.1.
+
+## Version 2.3.0 ##
 * Added support for OAuth2 Authentication - [More Details](https://developer.salesforce.com/docs/atlas.en-us.mc-app-development.meta/mc-app-development/access-token-s2s.htm)
 
 ## Version 2.2.0 ##

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfmc-fuelsdk-node",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfmc-fuelsdk-node",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -636,20 +636,20 @@
       "dev": true
     },
     "fuel-auth": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuel-auth/-/fuel-auth-3.1.0.tgz",
-      "integrity": "sha512-hHGm0hfSbdM8euf2BPH0yfwTrr0VOyYSjK9iCSF/C4L1tjSPEAIubIG4YwKab5Oamey5b21KpLLRBT12zn/CJQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fuel-auth/-/fuel-auth-3.2.1.tgz",
+      "integrity": "sha512-KNYls7mKssTvoF/hKIUbgr0P2r7c0rePQBeDFGWzBpJJvbrG0O7lAZHp8pwSyN91aaGhfmUiv7E+e7F5bbgfXw==",
       "requires": {
         "lodash.merge": "^4.6.1",
         "request": "~2.88.0"
       }
     },
     "fuel-rest": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuel-rest/-/fuel-rest-3.1.0.tgz",
-      "integrity": "sha512-V0xz61UL9VPEhj2qUWRDCHERFEaksbw7V7nwiQhKihlh7STqDQoC50L1Wpi/HhG8wJlXiXplGaYTTxaLa+wPww==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fuel-rest/-/fuel-rest-3.2.1.tgz",
+      "integrity": "sha512-F5nvwh8hrx5uLXl2BDSZFeT1D0SNNh8SCfE/Zeyid7E5Zphis02g4Zdq+9P+oVwb7/nx+3nGjCTm5973h6TUkw==",
       "requires": {
-        "fuel-auth": "3.1.0",
+        "fuel-auth": "^3.2.1",
         "lodash.clone": "~4.5.0",
         "lodash.isplainobject": "~4.0.4",
         "lodash.merge": "^4.6.1",
@@ -657,11 +657,11 @@
       }
     },
     "fuel-soap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fuel-soap/-/fuel-soap-2.1.0.tgz",
-      "integrity": "sha512-N9mPLTGIKqKMMxqUtCXoQZ2OMTDjVZQ1zxBaeJayiqAsINEWSBRUMbU/FKwSPTVdOUZDQKqUO0qNatI3CHe6jA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fuel-soap/-/fuel-soap-2.2.1.tgz",
+      "integrity": "sha512-IvwOmKamWPxJUmfshoSMfg2RQgfFAdlRWDr8kmbNI2epWHhsUxcjYU18Cd8QP/svY1XPedUct6Bi5IrvGSemAg==",
       "requires": {
-        "fuel-auth": "^3.1.0",
+        "fuel-auth": "^3.2.1",
         "lodash.clone": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "lodash.isplainobject": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfmc-fuelsdk-node",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Node SDK for performing REST, SOAP, Auth, and js object API calls with Salesforce Marketing Cloud Fuel.",
   "main": "./lib/ET_Client.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "fuel-auth": "^3.1.0",
-    "fuel-rest": "^3.1.0",
-    "fuel-soap": "^2.1.0",
+    "fuel-auth": "^3.2.1",
+    "fuel-rest": "^3.2.1",
+    "fuel-soap": "^2.2.1",
     "lodash.merge": "^4.6.1",
     "request": "^2.88.0",
     "uuid": "^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,7 @@ ansi-styles@^3.2.1:
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -340,6 +341,7 @@ espree@^4.0.0:
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.0.1:
   version "1.0.1"
@@ -634,8 +636,9 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
 js-yaml@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -963,6 +966,7 @@ slice-ansi@1.0.0:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
   version "1.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,28 +437,31 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fuel-auth@3.1.0, fuel-auth@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fuel-auth/-/fuel-auth-3.1.0.tgz#914cde147206291a37162e82a43f411be2e1f60c"
+fuel-auth@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/fuel-auth/-/fuel-auth-3.2.1.tgz#d7c268e4c330375a63b85aac76ec99b204555d27"
+  integrity sha512-KNYls7mKssTvoF/hKIUbgr0P2r7c0rePQBeDFGWzBpJJvbrG0O7lAZHp8pwSyN91aaGhfmUiv7E+e7F5bbgfXw==
   dependencies:
     lodash.merge "^4.6.1"
     request "~2.88.0"
 
-fuel-rest@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fuel-rest/-/fuel-rest-3.1.0.tgz#5edbf76091f9ebb0bc3cf55686d87d6dfd131b0e"
+fuel-rest@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/fuel-rest/-/fuel-rest-3.2.1.tgz#83b0510b54abc490de9d87b44382392789894d07"
+  integrity sha512-F5nvwh8hrx5uLXl2BDSZFeT1D0SNNh8SCfE/Zeyid7E5Zphis02g4Zdq+9P+oVwb7/nx+3nGjCTm5973h6TUkw==
   dependencies:
-    fuel-auth "3.1.0"
+    fuel-auth "^3.2.1"
     lodash.clone "~4.5.0"
     lodash.isplainobject "~4.0.4"
     lodash.merge "^4.6.1"
     request "~2.88.0"
 
-fuel-soap@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fuel-soap/-/fuel-soap-2.1.0.tgz#1adec287ccee572196fa307011e7e58c4b50a2cd"
+fuel-soap@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fuel-soap/-/fuel-soap-2.2.1.tgz#68cff84bb24761aad4f3d411faf03c4ae2ea5e40"
+  integrity sha512-IvwOmKamWPxJUmfshoSMfg2RQgfFAdlRWDr8kmbNI2epWHhsUxcjYU18Cd8QP/svY1XPedUct6Bi5IrvGSemAg==
   dependencies:
-    fuel-auth "^3.1.0"
+    fuel-auth "^3.2.1"
     lodash.clone "^4.5.0"
     lodash.isempty "^4.4.0"
     lodash.isplainobject "^4.0.3"


### PR DESCRIPTION
Ran `npm audit fix`.
Ran `yarn upgrade js-yaml@^3.12.0` - (^3.12.0 being the current semver).
Running `npm audit` and `yarn audit` after the previous 2 commands displays 0 vulnerabilities.

Bumped patch version: sfmc-fuelsdk-node@2.3.0 to sfmc-fuelsdk-node@2.3.1.
Updated ReadMe.md file.